### PR TITLE
Add feature ID's when encoding

### DIFF
--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -158,6 +158,8 @@ static void encode_point(struct mvt_agg_context *ctx, LWPOINT *point)
 	feature->type = VECTOR_TILE__TILE__GEOM_TYPE__POINT;
 	feature->has_type = 1;
 	feature->n_geometry = 3;
+	feature->id = ctx->c;
+	feature->has_id = 1;
 	feature->geometry = palloc(sizeof(*feature->geometry) * 3);
 	encode_ptarray_initial(ctx, MVT_POINT, point->point, feature->geometry);
 }


### PR DESCRIPTION
This is needed at least for mabox rendering libs to apply styles based
on attribute values.

(not much to add without a test or something).

cc/ @javisantana @Algunenano 