### PR TITLE
Optimize ST_AsMVTGeom for points

### DIFF
--- a/postgis/lwgeom_out_mvt.c
+++ b/postgis/lwgeom_out_mvt.c
@@ -60,7 +60,14 @@ Datum ST_AsMVTGeom(PG_FUNCTION_ARGS)
 	extent = PG_ARGISNULL(2) ? 4096 : PG_GETARG_INT32(2);
 	buffer = PG_ARGISNULL(3) ? 0 : PG_GETARG_INT32(3);
 	clip_geom = PG_ARGISNULL(4) ? true : PG_GETARG_BOOL(4);
-	lwgeom_out = mvt_geom(lwgeom_in, bounds, extent, buffer, clip_geom);
+	switch(lwgeom_in->type) {
+	case POINTTYPE:
+		lwgeom_out = mvt_geom_point(lwgeom_in, bounds, extent, buffer, clip_geom);
+		break;
+	default:
+		lwgeom_out = mvt_geom(lwgeom_in, bounds, extent, buffer, clip_geom);
+		break;
+	}
 	lwgeom_free(lwgeom_in);
 	if (lwgeom_out == NULL)
 		PG_RETURN_NULL();


### PR DESCRIPTION
This is the right query to generate an MVT with the 100K points example, before the patch:
```sql
EXPLAIN ANALYZE SELECT ST_AsMVT('dbe9fc29-ef99-4a4f-afc2-0f652dc9985b', 4096, 'geom', q) FROM (SELECT ST_AsMVTGeom(qbounds.the_geom_webmercator, ST_MakeBox2D(ST_Point(-20037508.5, 20037508.5), ST_Point(-20036897.00376892, 20036897.00376892)), 4096, 0,false) AS geom FROM (SELECT * FROM (SELECT * FROM test_100k_points) as cdbq WHERE "the_geom_webmercator" && ST_MakeEnvelope(-20037508.5, 20037508.5, -20036897.00376892, 20036897.00376892, 3857)) as qbounds) AS q;                                                                                                                    
                                                                                                                        QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=2983.48..2983.49 rows=1 width=32) (actual time=420.517..420.517 rows=1 loops=1)
   ->  Seq Scan on test_100k_points  (cost=0.00..2485.00 rows=99696 width=32) (actual time=0.011..45.132 rows=100000 loops=1)
         Filter: (the_geom_webmercator && '0103000020110F0000010000000500000000000048F81B73C100000048F81B734100000048F81B73C100700F10D21B734100700F10D21B73C100700F10D21B734100700F10D21B73C100000048F81B734100000048F81B73C100000048F81B7341'::geometry)
 Planning time: 0.921 ms
 Execution time: 422.185 ms
(5 rows)
```
Note the [`ST_AsMVTGeom`](https://postgis.net/docs/manual-dev/ST_AsMVTGeom.html), which is required in order to transform arbitrary geometries into MVT coordinate space (I missed that in the post draft).

That function not only transform the geometries in the sense of an affine transformation but it also does more things:

> Makes best effort to keep and even correct validity and might collapse geometry into a lower dimension in the process.

https://github.com/postgis/postgis/blob/a018a9ae11bfdd850ed948f1978ab42de8b24fd1/postgis/mvt.c#L703-L718

After profiling a little, and specifically for the points case, this patch makes it more than 2x faster:
```
EXPLAIN ANALYZE SELECT ST_AsMVT('dbe9fc29-ef99-4a4f-afc2-0f652dc9985b', 4096, 'geom', q) FROM (SELECT ST_AsMVTGeom(qbounds.the_geom_webmercator, ST_MakeBox2D(ST_Point(-20037508.5, 20037508.5), ST_Point(-20036897.00376892, 20036897.00376892)), 4096, 0,false) AS geom FROM (SELECT * FROM (SELECT * FROM test_100k_points) as cdbq WHERE "the_geom_webmercator" && ST_MakeEnvelope(-20037508.5, 20037508.5, -20036897.00376892, 20036897.00376892, 3857)) as qbounds) AS q;
                                                                                                                        QUERY PLAN                                                                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=2983.48..2983.49 rows=1 width=32) (actual time=182.544..182.544 rows=1 loops=1)
   ->  Seq Scan on test_100k_points  (cost=0.00..2485.00 rows=99696 width=32) (actual time=0.020..41.930 rows=100000 loops=1)
         Filter: (the_geom_webmercator && '0103000020110F0000010000000500000000000048F81B73C100000048F81B734100000048F81B73C100700F10D21B734100700F10D21B73C100700F10D21B734100700F10D21B73C100000048F81B734100000048F81B73C100000048F81B7341'::geometry)
 Planning time: 1.051 ms
 Execution time: 184.179 ms
(5 rows)
```

@javisantana there's duplicate code and lack of tests but with a little bit more work I think this kind of optimizations should have a good chance of reaching trunk. cc'ing @Algunenano for a first quick look.

