### PR TITLE
Fully qualify the query to spatial_ref_sys

### DIFF
--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -350,7 +350,7 @@ char* GetProj4StringSPI(int srid)
 	}
 
 	/* Execute the lookup query */
-	snprintf(proj4_spi_buffer, 255, "SELECT proj4text FROM public.spatial_ref_sys WHERE srid = %d LIMIT 1", srid);
+	snprintf(proj4_spi_buffer, 255, "SELECT proj4text FROM spatial_ref_sys WHERE srid = %d LIMIT 1", srid);
 	spi_result = SPI_exec(proj4_spi_buffer, 1);
 
 	/* Read back the PROJ4 text */

--- a/libpgcommon/lwgeom_transform.c
+++ b/libpgcommon/lwgeom_transform.c
@@ -350,7 +350,7 @@ char* GetProj4StringSPI(int srid)
 	}
 
 	/* Execute the lookup query */
-	snprintf(proj4_spi_buffer, 255, "SELECT proj4text FROM spatial_ref_sys WHERE srid = %d LIMIT 1", srid);
+	snprintf(proj4_spi_buffer, 255, "SELECT proj4text FROM public.spatial_ref_sys WHERE srid = %d LIMIT 1", srid);
 	spi_result = SPI_exec(proj4_spi_buffer, 1);
 
 	/* Read back the PROJ4 text */

--- a/postgis/postgis.sql.in
+++ b/postgis/postgis.sql.in
@@ -2707,14 +2707,16 @@ CREATE OR REPLACE FUNCTION postgis_transform_geometry(geometry,text,text,int)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME','transform_geom'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL
-	_COST_C_MED;
+	_COST_C_MED
+	SET search_path = @extschema@,pg_catalog;
 
 -- PostGIS equivalent of old function: transform(geometry,integer)
 CREATE OR REPLACE FUNCTION ST_Transform(geometry,integer)
 	RETURNS geometry
 	AS 'MODULE_PATHNAME','transform'
 	LANGUAGE 'c' IMMUTABLE STRICT _PARALLEL
-	_COST_C_MED;
+	_COST_C_MED
+	SET search_path = @extschema@,pg_catalog;
 
 -- Availability: 2.3.0
 CREATE OR REPLACE FUNCTION ST_Transform(geom geometry, to_proj text)


### PR DESCRIPTION
so that restores running in a "empty path" context will find the 'spatial_ref_sys' table used by st_transform(). Some users have st_transform() included in functional indexes, and when the indexes are rebuilt during restore, they will fail to find the spatial_ref_sys table.