### PR TITLE
CW handling after affine, as it was in 2.4.1

### DIFF
--- a/postgis/mvt.c
+++ b/postgis/mvt.c
@@ -756,10 +756,10 @@ LWGEOM *mvt_geom_fast(LWGEOM *lwgeom, const GBOX *gbox, uint32_t extent, uint32_
 		lwgeom_out = lwgeom;
 
 	/* if polygon(s) force clockwise as per MVT spec */
-	if (lwgeom_out->type == POLYGONTYPE ||
-		lwgeom_out->type == MULTIPOLYGONTYPE) {
-        lwgeom_force_clockwise(lwgeom_out);
-	}
+	// if (lwgeom_out->type == POLYGONTYPE ||
+	// 	lwgeom_out->type == MULTIPOLYGONTYPE) {
+	//         lwgeom_force_clockwise(lwgeom_out);
+	// }
 
 	/* transform to tile coordinate space */
 	memset(&affine, 0, sizeof(affine));
@@ -782,11 +782,14 @@ LWGEOM *mvt_geom_fast(LWGEOM *lwgeom, const GBOX *gbox, uint32_t extent, uint32_
 		return NULL;
 
 	/* if polygon(s) force valid as per MVT spec */
-    // if (lwgeom_out->type == POLYGONTYPE ||
-    //     lwgeom_out->type == MULTIPOLYGONTYPE) {
-    //     /* Watch out, does make_valid try to force orientation? */
-    //     lwgeom_out = lwgeom_make_valid(lwgeom_out);
-    // }
+	if (lwgeom_out->type == POLYGONTYPE ||
+	    lwgeom_out->type == MULTIPOLYGONTYPE)
+	{
+		/* Watch out, does make_valid try to force orientation? */
+		// lwgeom_out = lwgeom_make_valid(lwgeom_out);
+		lwgeom_force_clockwise(lwgeom_out);
+		lwgeom_reverse(lwgeom_out);
+	}
 
 	return lwgeom_out;
 }


### PR DESCRIPTION
Without knowing *why*, revert to 2.4.1 approach, applying CW force after the affine stage in the MVT generation. This seems counter intuitive, and even more it's not clear why it would make any difference, but, there it is.